### PR TITLE
support OpenShift local cluster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ Dockerfile.cross
 
 # Custom files and directories to ignore
 volume
+temp-prometheus.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.20 as builder
+FROM docker.io/golang:1.20 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/PROJECT
+++ b/PROJECT
@@ -6,7 +6,7 @@ domain: ibm.com
 layout:
 - go.kubebuilder.io/v4
 projectName: operator
-repo: github.com/metalcycling/susql
+repo: github.com/trent-s/susql-operator
 resources:
 - api:
     crdVersion: v1
@@ -15,6 +15,6 @@ resources:
   domain: ibm.com
   group: susql
   kind: LabelGroup
-  path: github.com/metalcycling/susql/api/v1
+  path: github.com/trent-s/susql-operator/api/v1
   version: v1
 version: "3"

--- a/README.md
+++ b/README.md
@@ -22,13 +22,19 @@ To install SusQL go to the `deployment` directory and run the command `$ bash de
     * In general, Kepler metrics are exposed, clusterwide, at:
 
       ```
-      http://<PROMETHEUS_SERVICE>.<PROMETHEUS_NAMESPACE>.svc.cluster.local:9090
+      http://<PROMETHEUS_SERVICE>.<PROMETHEUS_NAMESPACE>.<PROMETHEUS_DOMAIN>:9090
       ```
 
-      The deployment script assumes `PROMETHEUS_SERVICE=prometheus-k8s` and `PROMETHEUS_NAMESPACE=monitoring`. If this is not the case, use the deployment script as:
+      The deployment script assumes `PROMETHEUS_SERVICE=prometheus-k8s`, `PROMETHEUS_NAMESPACE=monitoring`, and `PROMETHEUS_DOMAIN=svc.cluster.local`. If this is not the case, use the deployment script as:
 
       ```
-      $ PROMETHEUS_SERVICE=<prometheus-service> PROMETHEUS_NAMESPACE=<prometheus-namespace> bash deploy.sh
+      $ PROMETHEUS_SERVICE=<prometheus-service> PROMETHEUS_NAMESPACE=<prometheus-namespace> PROMETHEUS_DOMAIN=<prometheus-domain> bash deploy.sh
+      ```
+
+	Alternatively, with a very unusual cluster such as a single node OpenShift local cluster, it may be necessary to set KEPLER_PROMETHEUS_URL directly such as:
+
+      ```
+      $ KEPLER_PROMETHEUS_URL=http://prometheus-k8s-openshift-monitoring.apps-crc.testing/api:9091 bash deploy.sh
       ```
 
 * Create the namespace `susql`

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -31,8 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	susqlv1 "github.com/metalcycling/susql/api/v1"
-	"github.com/metalcycling/susql/internal/controller"
+	susqlv1 "github.com/trent-s/susql-operator/api/v1"
+	"github.com/trent-s/susql-operator/internal/controller"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -13,7 +13,19 @@ if [[ -z ${PROMETHEUS_SERVICE} ]]; then
     PROMETHEUS_SERVICE="prometheus-k8s"
 fi
 
-KEPLER_PROMETHEUS_URL="http://${PROMETHEUS_SERVICE}.${PROMETHEUS_NAMESPACE}.svc.cluster.local:9090"
+if [[ -z ${PROMETHEUS_DOMAIN} ]]; then
+    PROMETHEUS_DOMAIN="svc.cluster.local"
+    PROMETHEUS_YAML="prometheus.yaml"
+else
+    PROMETHEUS_YAML="temp-prometheus.yaml"
+    sed -e 's/svc.cluster.local/'${PROMETHEUS_DOMAIN}'/g' prometheus.yaml >${PROMETHEUS_YAML}
+    sed -i -e 's/svc.cluster.local/'${PROMETHEUS_DOMAIN}'/g' susql-controller/values.yaml
+fi
+
+if [[ -z ${KEPLER_PROMETHEUS_URL} ]]; then
+    KEPLER_PROMETHEUS_URL="http://${PROMETHEUS_SERVICE}.${PROMETHEUS_NAMESPACE}.${PROMETHEUS_DOMAIN}:9090"
+fi
+
 
 # Check if namespace exists
 if [[ -z $(kubectl get namespaces --no-headers -o custom-columns=':{.metadata.name}' | grep susql) ]]; then
@@ -25,7 +37,7 @@ fi
 
 # Set SusQL installation variables
 SUSQL_DIR=".."
-SUSQL_REGISTRY="docker.io/metalcycling"
+SUSQL_REGISTRY="quay.io/trent-s"
 SUSQL_IMAGE_NAME="susql-controller"
 SUSQL_IMAGE_TAG="latest"
 
@@ -64,7 +76,7 @@ do
 
         helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
         helm repo update
-        helm upgrade --install prometheus -f prometheus.yaml --namespace susql prometheus-community/prometheus
+        helm upgrade --install prometheus -f ${PROMETHEUS_YAML} --namespace susql prometheus-community/prometheus
 
     elif [[ ${action} = "prometheus-undeploy" ]]; then
         echo "Undeploying Prometheus controller..."
@@ -77,10 +89,11 @@ do
         fi
 
     elif [[ ${action} = "susql-deploy" ]]; then
-        cd ${SUSQL_DIR} && make manifests && make install && cd -
+        cd ${SUSQL_DIR} && make manifests && make install
+	cd -
         helm upgrade --install --wait susql-controller ${SUSQL_DIR}/deployment/susql-controller --namespace susql \
             --set keplerPrometheusUrl="${KEPLER_PROMETHEUS_URL}" \
-            --set susqlPrometheusDatabaseUrl="http://prometheus-susql.susql.svc.cluster.local:9090" \
+            --set susqlPrometheusDatabaseUrl="http://prometheus-susql.susql.${PRMOETHEUS_DOMAIN}:9090" \
             --set susqlPrometheusMetricsUrl="http://0.0.0.0:8082" \
             --set imagePullPolicy="Always" \
             --set containerImage="${SUSQL_REGISTRY}/${SUSQL_IMAGE_NAME}:${SUSQL_IMAGE_TAG}"
@@ -91,7 +104,8 @@ do
         read response
 
         if [[ ${response} == "Y" || ${response} == "y" ]]; then
-            cd ${SUSQL_DIR} && make uninstall && cd -
+            cd ${SUSQL_DIR} && make uninstall
+	    cd -
         fi
 
         helm -n susql uninstall susql-controller

--- a/deployment/susql-controller/values.yaml
+++ b/deployment/susql-controller/values.yaml
@@ -7,7 +7,7 @@ namespace: susql
 #####################
 # Container image to be used
 #####################
-containerImage: docker.io/metalcycling/susql-controller
+containerImage: quay.io/trent-s/susql-controller
 
 #####################
 # Runtime hardware specifications

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/metalcycling/susql
+module github.com/trent-s/susql-operator
 
 go 1.20
 

--- a/internal/controller/labelgroup_controller.go
+++ b/internal/controller/labelgroup_controller.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
-	susql "github.com/metalcycling/susql/api/v1"
+	susql "github.com/trent-s/susql-operator/api/v1"
 )
 
 // LabelGroupReconciler reconciles a LabelGroup object

--- a/internal/controller/resource_manager.go
+++ b/internal/controller/resource_manager.go
@@ -21,7 +21,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	susql "github.com/metalcycling/susql/api/v1"
+	susql "github.com/trent-s/susql-operator/api/v1"
 	v1 "k8s.io/api/core/v1"
 )
 

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -30,7 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	susqlv1 "github.com/metalcycling/susql/api/v1"
+	susqlv1 "github.com/trent-s/susql-operator/api/v1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/test/labelgroups.sh
+++ b/test/labelgroups.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-namespace=metalcycling
+namespace=sustainablecomputing
 
 t_start=$(date +%s.%N)
 


### PR DESCRIPTION
There are two primary changes in this PR (which should DCO compliant and simplified):
- Add two new environment variables to enable installation on an OpenShift Local cluster. `PROMETHEUS_DOMAIN` and `KEPLER_PROMETHEUS_URL`.  Usage convention is added to the README.md file.
- Fix an installation bug that causes the current working directory to take on an unexpected value on error conditions.  Specifically with the original code `cd ${SUSQL_DIR} && make manifests && make install && cd - ` if either of the `make` commands fail, the the current working directly will stay in `${SUSQK_DIR}` and not return to the starting point as intended with `cd -`. The simplest solution to ensure that the final `cd` is executed is to separate it out on a separate line as follows:
```
cd ${SUSQL_DIR} && make manifests && make install
cd -
```

Signed-off-by: Scott Trent <trent@jp.ibm.com>
