### PR TITLE
resolve issue 12-enable github action build and push

### DIFF
--- a/.github/publish-images/action.yaml
+++ b/.github/publish-images/action.yaml
@@ -4,6 +4,9 @@ inputs:
   image_registry:
     description: "image registry"
     required: true
+  image_url:
+    description: "url to image in registry"
+    required: true
   registry_login:
     description: "registry username"
     required: true
@@ -31,28 +34,18 @@ runs:
         cache: true
 
     - name: Login to Image Registry
-      uses: docker/login-action@v2
+      uses: redhat-actions/podman-login@v1
       if: "!startsWith(inputs.image_registry, 'localhost')"
       with:
         registry: ${{ inputs.image_registry }}
         username: ${{ inputs.registry_login }}
         password: ${{ inputs.registry_token }}
 
-    - name: Build Operator
+    - name: Build Operator and image and then push
       shell: bash
       run: |
-        make build
+        make build && make docker-build && make docker-push
       env:
         VERSION: ${{ inputs.version }}
-        IMG: ${{ inputs.image_registry }}
-        ADDITIONAL_TAGS: ${{ inputs.additional_tags }}
-
-    - name: Push Images
-      shell: bash
-      if: "!startsWith(inputs.image_registry, 'localhost')"
-      run: |
-        make docker-build docker-push
-      env:
-        VERSION: ${{ inputs.version }}
-        IMG: ${{ inputs.image_registry }}
+        IMG: ${{ format('{0}:{1}', inputs.image_url, 'latest') }}
         ADDITIONAL_TAGS: ${{ inputs.additional_tags }}

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -2,11 +2,12 @@ name: Publish Images
 
 on:
   push:
-    branches: [ v1alpha1 ]
+    branches: [ main ]
 
 jobs:
   publish:
       name: Publish operator container images
+      environment: SusQL-Environment
       runs-on: ubuntu-latest
       steps:
         - name: Checkout source
@@ -24,13 +25,14 @@ jobs:
           id: additional_tags
           shell: bash
           run: |
-            echo "result=$(git rev-parse --short HEAD),v1alpha1" >> $GITHUB_OUTPUT
+            echo "result=$(git rev-parse --short HEAD),main" >> $GITHUB_OUTPUT
 
         - name: build and publish images to external registry
           uses: ./.github/publish-images
           with:
-            image_registry: ${{ vars.IMG_BASE }}
-            registry_login: ${{ secrets.BOT_NAME }}
-            registry_token: ${{ secrets.BOT_TOKEN }}
+            image_url: ${{ vars.IMG }}
+            image_registry: ${{ vars.REGISTRY }}
+            registry_login: ${{ secrets.QUAY_BOT_NAME }}
+            registry_token: ${{ secrets.QUAY_BOT_TOKEN }}
             version: ${{ steps.version.outputs.version }}
             additional_tags: ${{ steps.additional_tags.outputs.result }}

--- a/deployment/deploy.sh
+++ b/deployment/deploy.sh
@@ -57,7 +57,7 @@ fi
 # Set SusQL installation variables
 SUSQL_DIR=".."
 SUSQL_REGISTRY="quay.io/sustainable_computing_io"
-SUSQL_IMAGE_NAME="susql-controller"
+SUSQL_IMAGE_NAME="susql_operator"
 SUSQL_IMAGE_TAG="latest"
 
 # Actions to perform, separated by comma

--- a/deployment/susql-controller/values.yaml
+++ b/deployment/susql-controller/values.yaml
@@ -7,7 +7,7 @@ namespace: openshift-kepler-operator
 #####################
 # Container image to be used
 #####################
-containerImage: quay.io/sustainable_computing_io/susql-controller
+containerImage: quay.io/sustainable_computing_io/susql_operator
 
 #####################
 # Runtime hardware specifications


### PR DESCRIPTION
- Switch from docker/login-action to redhat-actions/podman-login to match project use of podman
- Use newly added secrets and container image location
- Enable automatic build and push only for main branch (so that development branches do not overwrite official image)