### PR TITLE
Refactor to only call kubectl once - First task in issue 25

### DIFF
--- a/test/labelgroups.sh
+++ b/test/labelgroups.sh
@@ -4,12 +4,15 @@ namespace=default
 
 t_start=$(date +%s.%N)
 
-for labelgroup in $(kubectl -n ${namespace} get labelgroups -o custom-columns=':{.metadata.name}')
+alldata=$(kubectl -n ${namespace} get labelgroups -o json)
+
+for labelgroup in $(echo ${alldata} | jq -cr '.items[].metadata.name')
 do
-    totalEnergy=$(kubectl -n ${namespace} get labelgroup ${labelgroup} -o jsonpath='{.status.totalEnergy}')
-    susqlPrometheusQuery=$(kubectl -n ${namespace} get labelgroup ${labelgroup} -o jsonpath='{.status.susqlPrometheusQuery}')
-    phase=$(kubectl -n ${namespace} get labelgroup ${labelgroup} -o jsonpath='{.status.phase}')
-    labels=$(kubectl -n ${namespace} get labelgroup ${labelgroup} -o jsonpath='{.spec.labels}')
+    newdata=$(echo ${alldata} | jq '.items[] | select(.metadata.name=="'${labelgroup}'")')
+    totalEnergy=$(echo ${newdata} | jq -cr '.status.totalEnergy')
+    susqlPrometheusQuery=$(echo ${newdata} | jq -cr '.status.susqlPrometheusQuery')
+    phase=$(echo ${newdata} | jq -cr '.status.phase')
+    labels=$(echo ${newdata} | jq -cr '.spec.labels')
 
     echo "LabelGroup: ${labelgroup}"
     echo "    - Labels: ${labels}"

--- a/test/susqltop
+++ b/test/susqltop
@@ -3,21 +3,24 @@
 # usage command -n "comma,delimited,list,of,namespaces" to limit to specified namespaces
 # usage command to display SusQL energy data on all namespaces that have such data
 
+alldata=$(kubectl get labelgroups -o json --all-namespaces)
+
 if [[ ${#} -gt 1 && ${1} -eq '-n' ]]
 then
 	ns=$(echo ${2} | tr ',' ' ')
 else
-	ns=$(oc projects -q)
+	ns=$(echo ${alldata} | jq -r '.items[].metadata.namespace' | uniq)
 fi
 
 printf  '%-20s%-40s%-40s%-20s\n' NameSpace LabelGroup Labels TotalEnergy
 
 for namespace in ${ns}
 do
-    for labelgroup in $(kubectl -n ${namespace} get labelgroups -o custom-columns=':{.metadata.name}')
+    for labelgroup in $(echo ${alldata} | jq '.items[] | select(.metadata.namespace=="'${namespace}'")' | jq -r  '.metadata.name')
     do
-        totalEnergy=$(kubectl -n ${namespace} get labelgroup ${labelgroup} -o jsonpath='{.status.totalEnergy}')
-        labels=$(kubectl -n ${namespace} get labelgroup ${labelgroup} -o jsonpath='{.spec.labels}')
+        newdata=$(echo ${alldata} | jq '.items[] | select(.metadata.namespace=="'${namespace}'" and .metadata.name=="'${labelgroup}'")')
+	totalEnergy=$(echo ${newdata} | jq -cr '.status.totalEnergy')
+	labels=$(echo ${newdata} | jq -cr '.spec.labels')
         printf '%-20s%-40s%-40s%-20s\n' ${namespace} ${labelgroup} ${labels} ${totalEnergy}
     done
 done | sort -nr -k4 | head -n 20


### PR DESCRIPTION
Refactored scripts to first gather relevant information in json format with a single invocation of `kubectl`. Then extract specific information from json data when needed with the `jq` command.