### PR TITLE
Code cleanup

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/publish-images.yaml
+++ b/.github/workflows/publish-images.yaml
@@ -12,9 +12,9 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - name: Checkout source
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
-        - uses: actions/setup-go@v5
+        - uses: actions/setup-go@v6
           with:
             go-version-file: go.mod
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone the code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.24-alpine as builder
+FROM golang:1.24.7-alpine as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Energy of the group of pods is exposed in two ways:
 
 ## License
 
-Copyright 2023, 2024, 2025.
+Copyright 2023, 2024, 2025, 2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/api/v1/labelgroup_types.go
+++ b/api/v1/labelgroup_types.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024, 2025.
+Copyright 2024, 2025, 2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -31,7 +31,7 @@ type LabelGroupSpec struct {
 	// Do not use the most recent value stored in the database
 	DisableUsingMostRecentValue bool `json:"disableUsingMostRecentValue,omitempty"`
 
-	// List of labels to be tracked for energy measurments (up to 5)
+	// List of labels to be tracked for energy measurements (up to 6)
 	Labels []string `json:"labels,omitempty"`
 }
 

--- a/bundle/manifests/susql-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/susql-operator.clusterserviceversion.yaml
@@ -28,7 +28,7 @@ metadata:
     capabilities: Basic Install
     categories: Monitoring
     containerImage: quay.io/sustainable_computing_io/susql_operator:0.0.34
-    createdAt: "2025-07-10T01:20:37Z"
+    createdAt: "2026-03-18T02:23:39Z"
     description: 'Aggregates energy and CO2 emission data for pods tagged with SusQL
       labels '
     features.operators.openshift.io/disconnected: "false"

--- a/bundle/manifests/susql.ibm.com_labelgroups.yaml
+++ b/bundle/manifests/susql.ibm.com_labelgroups.yaml
@@ -43,8 +43,8 @@ spec:
                 description: Do not use the most recent value stored in the database
                 type: boolean
               labels:
-                description: List of labels to be tracked for energy measurments (up
-                  to 5)
+                description: List of labels to be tracked for energy measurements
+                  (up to 6)
                 items:
                   type: string
                 type: array

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023, 2024, 2025.
+Copyright 2023, 2024, 2025, 2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/tls"
 	"flag"
+	"fmt"
 	"os"
 	"strconv"
 	"time"
@@ -116,7 +117,7 @@ func main() {
 	flag.StringVar(&carbonMethod, "carbon-method", carbonMethodEnv, "Method used to calculate CO2 emissions")
 	flag.StringVar(&carbonIntensity, "carbon-intensity", carbonIntensityEnv, "Carbon Intensity Factor in grams CO2 / Joule")
 	flag.StringVar(&carbonIntensityUrl, "carbon-intensity-url", carbonIntensityUrlEnv, "URL used to query calculate carbon intensity")
-	flag.StringVar(&carbonLocation, "carbon-location", carbonLocationEnv, "Location identfier used in carbon intensity query")
+	flag.StringVar(&carbonLocation, "carbon-location", carbonLocationEnv, "Location identifier used in carbon intensity query")
 	flag.StringVar(&carbonQueryRate, "carbon-query-rate", carbonQueryRateEnv, "How often to query carbon intensity query (seconds)")
 	flag.StringVar(&carbonQueryFilter, "carbon-query-filter", carbonQueryFilterEnv, "Parameter to extract carbon intensity from JSON returned by query")
 	flag.StringVar(&carbonQueryConv2J, "carbon-query-conv-2j", carbonQueryConv2JEnv, "Factor to convert carbon intensity returned by query to grams CO2 / Joule")
@@ -212,9 +213,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	// TODO: verify that carbonMethod is an expected value. If not log warning and set to default value.
-	// (static, simpledynamic, casdk)
-	// Note: assume that carbonIntensityUrl, carbonLocation, and carbonQueryFilter are OK. If not, we will log errors at runtime.
+	// Validate carbonMethod
+	validCarbonMethods := map[string]bool{
+		"static":        true,
+		"simpledynamic": true,
+		"casdk":         true,
+	}
+	if !validCarbonMethods[carbonMethod] {
+		susqlLog.Info(fmt.Sprintf("WARNING: Invalid carbon-method '%s'. Valid options are: static, simpledynamic, casdk. Defaulting to 'static'.", carbonMethod))
+		carbonMethod = "static"
+	}
 
 	samplingRateInteger, err := strconv.Atoi(samplingRate)
 	if err != nil {

--- a/config/crd/bases/susql.ibm.com_labelgroups.yaml
+++ b/config/crd/bases/susql.ibm.com_labelgroups.yaml
@@ -43,8 +43,8 @@ spec:
                 description: Do not use the most recent value stored in the database
                 type: boolean
               labels:
-                description: List of labels to be tracked for energy measurments (up
-                  to 5)
+                description: List of labels to be tracked for energy measurements
+                  (up to 6)
                 items:
                   type: string
                 type: array

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/sustainable-computing-io/susql-operator
 
 go 1.24.0
 
+toolchain go1.24.13
+
 require (
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.22.0

--- a/internal/controller/carbon_query.go
+++ b/internal/controller/carbon_query.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023, 2024.
+Copyright 2023, 2024, 2025, 2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -32,6 +32,11 @@ func queryCarbonIntensity(url string, location string, filter string, conv2J flo
 	if err != nil {
 		return 0.0, fmt.Errorf("queryCarbonIntensity: %w\nURL=%s", err, queryUrl)
 	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return 0.0, fmt.Errorf("queryCarbonIntensity: HTTP request failed with status %d\nURL=%s", response.StatusCode, queryUrl)
+	}
 
 	responseData, err := io.ReadAll(response.Body)
 	if err != nil {
@@ -56,14 +61,19 @@ func queryCarbonIntensity(url string, location string, filter string, conv2J flo
 func querySimpleCarbonIntensity(url string, location string, filter string, conv2J float64) (float64, error) {
 	queryUrl := fmt.Sprintf(url, location)
 
-	response, err := http.Get(fmt.Sprintf(url, location))
+	response, err := http.Get(queryUrl)
 	if err != nil {
 		return 0.0, fmt.Errorf("querySimpleCarbonIntensity: %w\nURL=%s", err, queryUrl)
+	}
+	defer response.Body.Close()
+
+	if response.StatusCode != http.StatusOK {
+		return 0.0, fmt.Errorf("querySimpleCarbonIntensity: HTTP request failed with status %d\nURL=%s", response.StatusCode, queryUrl)
 	}
 
 	responseData, err := io.ReadAll(response.Body)
 	if err != nil {
-		return 0.0, fmt.Errorf("queryCarbonSimpleIntensity: %w\nURL=%s\nresponse=%s", err, queryUrl, string(responseData))
+		return 0.0, fmt.Errorf("querySimpleCarbonIntensity: %w\nURL=%s\nresponse=%s", err, queryUrl, string(responseData))
 	}
 
 	carbonIntensityString := gjson.Get(string(responseData), filter).String()

--- a/internal/controller/labelgroup_controller.go
+++ b/internal/controller/labelgroup_controller.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023, 2024, 2025.
+Copyright 2023, 2024, 2025, 2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	coreruntime "runtime"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -52,6 +53,7 @@ type LabelGroupReconciler struct {
 	CarbonQueryFilter             string
 	CarbonQueryConv2J             float64
 	Logger                        logr.Logger
+	carbonMutex                   sync.RWMutex // Protects carbon intensity fields
 }
 
 const (
@@ -119,9 +121,14 @@ func (r *LabelGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	// Is it time to update the Carbon Intensity value?
 	// TODO: put this code only in Reloading and Aggregating cases
 	if r.CarbonMethod == "simpledynamic" {
+		r.carbonMutex.RLock()
 		currentEpoch := time.Now().Unix()
-		if (currentEpoch-r.CarbonIntensityTimeStamp) > r.CarbonQueryRate && (currentEpoch-r.CarbonIntensityErrorTimeStamp) > carbonRetryDelay {
+		shouldUpdate := (currentEpoch-r.CarbonIntensityTimeStamp) > r.CarbonQueryRate && (currentEpoch-r.CarbonIntensityErrorTimeStamp) > carbonRetryDelay
+		r.carbonMutex.RUnlock()
+
+		if shouldUpdate {
 			newCarbonIntensity, err := querySimpleCarbonIntensity(r.CarbonIntensityUrl, r.CarbonLocation, r.CarbonQueryFilter, r.CarbonQueryConv2J)
+			r.carbonMutex.Lock()
 			if err == nil {
 				r.CarbonIntensity = newCarbonIntensity
 				r.CarbonIntensityTimeStamp = currentEpoch
@@ -131,12 +138,18 @@ func (r *LabelGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				r.CarbonIntensityErrorTimeStamp = currentEpoch
 				r.Logger.V(0).Error(err, "[Reconcile-simpledynamic] Unable to query carbon intensity.")
 			}
+			r.carbonMutex.Unlock()
 		}
 	}
 	if r.CarbonMethod == "casdk" {
+		r.carbonMutex.RLock()
 		currentEpoch := time.Now().Unix()
-		if (currentEpoch-r.CarbonIntensityTimeStamp) > r.CarbonQueryRate && (currentEpoch-r.CarbonIntensityErrorTimeStamp) > carbonRetryDelay {
+		shouldUpdate := (currentEpoch-r.CarbonIntensityTimeStamp) > r.CarbonQueryRate && (currentEpoch-r.CarbonIntensityErrorTimeStamp) > carbonRetryDelay
+		r.carbonMutex.RUnlock()
+
+		if shouldUpdate {
 			newCarbonIntensity, err := queryCarbonIntensity(r.CarbonIntensityUrl, r.CarbonLocation, r.CarbonQueryFilter, r.CarbonQueryConv2J)
+			r.carbonMutex.Lock()
 			if err == nil {
 				r.CarbonIntensity = newCarbonIntensity
 				r.CarbonIntensityTimeStamp = currentEpoch
@@ -146,6 +159,7 @@ func (r *LabelGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				r.CarbonIntensityErrorTimeStamp = currentEpoch
 				r.Logger.V(0).Error(err, "[Reconcile-casdk] Unable to query carbon intensity.")
 			}
+			r.carbonMutex.Unlock()
 		}
 	}
 
@@ -224,7 +238,7 @@ func (r *LabelGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		r.Logger.V(5).Info("[Reconcile-Reloading] Entered reloading case.")
 		// Reload data from existing database
 		if !labelGroup.Spec.DisableUsingMostRecentValue {
-			totalEnergy, err := r.GetMostRecentValue(labelGroup.Status.SusQLPrometheusEnergyQuery)
+			totalEnergy, err := r.GetMostRecentValueWithContext(ctx, labelGroup.Status.SusQLPrometheusEnergyQuery)
 
 			if err != nil {
 				r.Logger.V(0).Error(err, "[Reconcile-Reloading] Couldn't retrieve most recent energy value.")
@@ -233,7 +247,7 @@ func (r *LabelGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 			labelGroup.Status.TotalEnergy = fmt.Sprintf("%f", totalEnergy)
 
-			totalCarbon, err := r.GetMostRecentValue(labelGroup.Status.SusQLPrometheusCarbonQuery)
+			totalCarbon, err := r.GetMostRecentValueWithContext(ctx, labelGroup.Status.SusQLPrometheusCarbonQuery)
 
 			if err != nil {
 				r.Logger.V(0).Error(err, "[Reconcile-Reloading] Couldn't retrieve most recent carbon value.")
@@ -270,7 +284,7 @@ func (r *LabelGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 
 		// Aggregate Kepler measurements for these set of pods
-		metricValues, err := r.GetMetricValuesForPodNames(r.KeplerMetricName, podsInNamespace, labelGroup.Namespace)
+		metricValues, err := r.GetMetricValuesForPodNamesWithContext(ctx, r.KeplerMetricName, podsInNamespace, labelGroup.Namespace)
 
 		if err != nil {
 			r.Logger.V(0).Error(err, "[Reconcile-Aggregating] Querying Prometheus didn't work.")
@@ -326,7 +340,12 @@ func (r *LabelGroupReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			totalCarbon = 0.0
 		}
 
-		totalCarbon = totalCarbon + (totalEnergy-originalTotalEnergy)*r.CarbonIntensity
+		// Read carbon intensity with lock protection
+		r.carbonMutex.RLock()
+		currentCarbonIntensity := r.CarbonIntensity
+		r.carbonMutex.RUnlock()
+
+		totalCarbon = totalCarbon + (totalEnergy-originalTotalEnergy)*currentCarbonIntensity
 		labelGroup.Status.TotalCarbon = fmt.Sprintf("%.10f", totalCarbon)
 
 		if err := r.Status().Update(ctx, labelGroup); err != nil {
@@ -365,7 +384,9 @@ func (r *LabelGroupReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.Logger.V(5).Info("[SetupWithManager] Initializing Metrics Exporter.")
 
 	// Start server to export metrics
-	r.InitializeMetricsExporter()
+	if err := r.InitializeMetricsExporter(); err != nil {
+		return err
+	}
 
 	return controllerManager
 }

--- a/internal/controller/prometheus_manager.go
+++ b/internal/controller/prometheus_manager.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023, 2024.
+Copyright 2023, 2024, 2025, 2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -35,6 +34,10 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 )
 
+const (
+	maxQueryLength = 10000 // Maximum allowed query string length
+)
+
 var (
 	maxQueryTime                         = "1y" // Look back 'maxQueryTime' for the most recent value
 	keplerRoundTripper http.RoundTripper = nil
@@ -43,6 +46,10 @@ var (
 
 // Functions to get data from the cluster
 func (r *LabelGroupReconciler) GetMostRecentValue(susqlPrometheusQuery string) (float64, error) {
+	return r.GetMostRecentValueWithContext(context.Background(), susqlPrometheusQuery)
+}
+
+func (r *LabelGroupReconciler) GetMostRecentValueWithContext(ctx context.Context, susqlPrometheusQuery string) (float64, error) {
 	// Return the most recent value found in the table
 	if susqlRoundTripper == nil {
 		if strings.HasPrefix(r.SusQLPrometheusDatabaseUrl, "https://") {
@@ -56,30 +63,28 @@ func (r *LabelGroupReconciler) GetMostRecentValue(susqlPrometheusQuery string) (
 	})
 
 	if err != nil {
-		r.Logger.V(0).Error(err, "[GetMostRecentValue] Couldn't create HTTP client.\n"+
-			fmt.Sprintf("\tQuery:  %s\n", susqlPrometheusQuery)+
-			fmt.Sprintf("\tSusQLPrometheusDatabaseUrl:  %s\n", r.SusQLPrometheusDatabaseUrl))
-		os.Exit(1)
+		return 0.0, fmt.Errorf("[GetMostRecentValueWithContext] couldn't create HTTP client: %w (Query: %s, URL: %s)",
+			err, susqlPrometheusQuery, r.SusQLPrometheusDatabaseUrl)
 	}
 
 	v1api := v1.NewAPI(client)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
 	queryString := fmt.Sprintf("max_over_time(%s[%s])", susqlPrometheusQuery, maxQueryTime)
-	results, warnings, err := v1api.Query(ctx, queryString, time.Now(), v1.WithTimeout(0*time.Second))
+	results, warnings, err := v1api.Query(queryCtx, queryString, time.Now(), v1.WithTimeout(0*time.Second))
 
-	r.Logger.V(5).Info(fmt.Sprintf("[GetMostRecentValue] Query: %s", queryString)) // trace
-	r.Logger.V(5).Info(fmt.Sprintf("[GetMostRecentValue] Results: '%v'", results)) // trace
+	r.Logger.V(5).Info(fmt.Sprintf("[GetMostRecentValueWithContext] Query: %s", queryString)) // trace
+	r.Logger.V(5).Info(fmt.Sprintf("[GetMostRecentValueWithContext] Results: '%v'", results)) // trace
 
 	if len(warnings) > 0 {
-		r.Logger.V(0).Info(fmt.Sprintf("WARNING [GetMostRecentValue] %v\n", warnings) +
+		r.Logger.V(0).Info(fmt.Sprintf("WARNING [GetMostRecentValueWithContext] %v\n", warnings) +
 			fmt.Sprintf("\tQuery:  %s\n", queryString) +
 			fmt.Sprintf("\tSusQLPrometheusDatabaseUrl:  %s", r.SusQLPrometheusDatabaseUrl))
 	}
 
 	if err != nil {
-		r.Logger.V(0).Error(err, "[GetMostRecentValue] Querying Prometheus didn't work.\n"+
+		r.Logger.V(0).Error(err, "[GetMostRecentValueWithContext] Querying Prometheus didn't work.\n"+
 			fmt.Sprintf("\tQuery:  %s\n", queryString)+
 			fmt.Sprintf("\tSusQLPrometheusDatabaseUrl:  %s\n", r.SusQLPrometheusDatabaseUrl))
 		return 0.0, err
@@ -93,6 +98,15 @@ func (r *LabelGroupReconciler) GetMostRecentValue(susqlPrometheusQuery string) (
 }
 
 func (r *LabelGroupReconciler) GetMetricValuesForPodNames(metricName string, podNames []string, namespaceName string) (map[string]float64, error) {
+	return r.GetMetricValuesForPodNamesWithContext(context.Background(), metricName, podNames, namespaceName)
+}
+
+func (r *LabelGroupReconciler) GetMetricValuesForPodNamesWithContext(ctx context.Context, metricName string, podNames []string, namespaceName string) (map[string]float64, error) {
+	// Check for empty pod list
+	if len(podNames) == 0 {
+		return make(map[string]float64), nil
+	}
+
 	if keplerRoundTripper == nil {
 		if strings.HasPrefix(r.KeplerPrometheusUrl, "https://") {
 			rttls := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: true}}
@@ -105,32 +119,49 @@ func (r *LabelGroupReconciler) GetMetricValuesForPodNames(metricName string, pod
 	})
 
 	if err != nil {
-		r.Logger.V(0).Error(err, "[GetMetricValuesForPodNames] Couldn't create an HTTP client.\n"+
-			fmt.Sprintf("\tmetricName: %s\n", metricName)+
-			fmt.Sprintf("\tKeplerPrometheusUrl: %s\n", r.KeplerPrometheusUrl))
-		os.Exit(1)
+		return nil, fmt.Errorf("[GetMetricValuesForPodNamesWithContext] couldn't create HTTP client: %w (metricName: %s, URL: %s)",
+			err, metricName, r.KeplerPrometheusUrl)
 	}
 
 	v1api := v1.NewAPI(client)
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	//	queryString := fmt.Sprintf("%s{pod_name=~\"%s\",mode=\"dynamic\"}", metricName, strings.Join(podNames, "|"))
+	// Build query string efficiently using strings.Builder
+	var queryBuilder strings.Builder
 
-	// new query for issue 2: can improve runtime efficiency...
-	queryString := fmt.Sprintf("sum(%s{pod_name=\"%s\",container_namespace=\"%s\",mode=\"dynamic\"})", metricName, podNames[0], namespaceName)
-	queryString = queryString + "+" + fmt.Sprintf("sum(%s{pod_name=\"%s\",container_namespace=\"%s\",mode=\"idle\"})", metricName, podNames[0], namespaceName)
+	// Estimate capacity to reduce allocations
+	estimatedSize := len(podNames) * 200 // Rough estimate per pod
+	queryBuilder.Grow(estimatedSize)
+
+	// Build query for first pod
+	queryBuilder.WriteString(fmt.Sprintf("sum(%s{pod_name=\"%s\",container_namespace=\"%s\",mode=\"dynamic\"})", metricName, podNames[0], namespaceName))
+	queryBuilder.WriteString("+")
+	queryBuilder.WriteString(fmt.Sprintf("sum(%s{pod_name=\"%s\",container_namespace=\"%s\",mode=\"idle\"})", metricName, podNames[0], namespaceName))
+
+	// Build query for remaining pods
 	for i := 1; i < len(podNames); i++ {
-		queryString = queryString + "+" + fmt.Sprintf("sum(%s{pod_name=\"%s\",container_namespace=\"%s\",mode=\"dynamic\"})", metricName, podNames[i], namespaceName)
-		queryString = queryString + "+" + fmt.Sprintf("sum(%s{pod_name=\"%s\",container_namespace=\"%s\",mode=\"idle\"})", metricName, podNames[i], namespaceName)
+		queryBuilder.WriteString("+")
+		queryBuilder.WriteString(fmt.Sprintf("sum(%s{pod_name=\"%s\",container_namespace=\"%s\",mode=\"dynamic\"})", metricName, podNames[i], namespaceName))
+		queryBuilder.WriteString("+")
+		queryBuilder.WriteString(fmt.Sprintf("sum(%s{pod_name=\"%s\",container_namespace=\"%s\",mode=\"idle\"})", metricName, podNames[i], namespaceName))
+
+		// Check if query is getting too long
+		if queryBuilder.Len() > maxQueryLength {
+			r.Logger.V(0).Error(fmt.Errorf("query string exceeds maximum length of %d characters", maxQueryLength),
+				"[GetMetricValuesForPodNames] Query too long, truncating pod list")
+			break
+		}
 	}
 
-	results, warnings, err := v1api.Query(ctx, queryString, time.Now(), v1.WithTimeout(0*time.Second))
+	queryString := queryBuilder.String()
 
-	r.Logger.V(5).Info(fmt.Sprintf("[GetMetricValuesForPodNames] Query: %s", queryString)) // trace
+	results, warnings, err := v1api.Query(queryCtx, queryString, time.Now(), v1.WithTimeout(0*time.Second))
+
+	r.Logger.V(5).Info(fmt.Sprintf("[GetMetricValuesForPodNamesWithContext] Query: %s", queryString)) // trace
 
 	if err != nil {
-		r.Logger.V(0).Error(err, "[GetMetricValuesForPodNames] Querying Prometheus didn't work.\n"+
+		r.Logger.V(0).Error(err, "[GetMetricValuesForPodNamesWithContext] Querying Prometheus didn't work.\n"+
 			fmt.Sprintf("\tmetricName: %s\n", metricName)+
 			fmt.Sprintf("\tKeplerPrometheusUrl: %s\n", r.KeplerPrometheusUrl)+
 			fmt.Sprintf("\tqueryString: %s\n", queryString))
@@ -138,7 +169,7 @@ func (r *LabelGroupReconciler) GetMetricValuesForPodNames(metricName string, pod
 	}
 
 	if len(warnings) > 0 {
-		r.Logger.V(0).Info(fmt.Sprintf("WARNING [GetMetricValuesForPodNames] %v\n", warnings) +
+		r.Logger.V(0).Info(fmt.Sprintf("WARNING [GetMetricValuesForPodNamesWithContext] %v\n", warnings) +
 			fmt.Sprintf("\tmetricName: %s\n", metricName) +
 			fmt.Sprintf("\tKeplerPrometheusUrl: %s\n", r.KeplerPrometheusUrl) +
 			fmt.Sprintf("\tqueryString: %s", queryString))
@@ -147,7 +178,7 @@ func (r *LabelGroupReconciler) GetMetricValuesForPodNames(metricName string, pod
 	metricValues := make(map[string]float64, len(results.(model.Vector)))
 
 	for _, result := range results.(model.Vector) {
-		r.Logger.V(5).Info(fmt.Sprintf("[GetMetricValuesForPodNames] Container id %s value is %f.", string(result.Metric["container_id"]), float64(result.Value))) // trace
+		r.Logger.V(5).Info(fmt.Sprintf("[GetMetricValuesForPodNamesWithContext] Container id %s value is %f.", string(result.Metric["container_id"]), float64(result.Value))) // trace
 		metricValues[string(result.Metric["container_id"])] = float64(result.Value)
 	}
 
@@ -177,7 +208,7 @@ var (
 	prometheusHandler  http.Handler
 )
 
-func (r *LabelGroupReconciler) InitializeMetricsExporter() {
+func (r *LabelGroupReconciler) InitializeMetricsExporter() error {
 	// Initiate the exporting of prometheus metrics for the energy
 	r.Logger.V(5).Info("Entering InitializeMetricsExporter().")
 	if prometheusRegistry == nil {
@@ -187,22 +218,23 @@ func (r *LabelGroupReconciler) InitializeMetricsExporter() {
 		prometheusHandler = promhttp.HandlerFor(prometheusRegistry, promhttp.HandlerOpts{Registry: prometheusRegistry})
 		http.Handle("/metrics", prometheusHandler)
 
-		if metricsUrl, parseErr := url.Parse(r.SusQLPrometheusMetricsUrl); parseErr == nil {
-			r.Logger.V(2).Info(fmt.Sprintf("[InitializeMetricsExporter] Serving metrics at '%s:%s'...\n", metricsUrl.Hostname(), metricsUrl.Port()))
-
-			go func() {
-				err := http.ListenAndServe(metricsUrl.Hostname()+":"+metricsUrl.Port(), nil)
-
-				if err != nil {
-					r.Logger.V(0).Error(err, "PANIC [InitializeMetricsExporter] ListenAndServe")
-					panic("PANIC [InitializeMetricsExporter]: ListenAndServe: " + err.Error())
-				}
-			}()
-		} else {
-			r.Logger.V(0).Error(parseErr, fmt.Sprintf("PANIC [InitializeMetricsExporter] Parsing the URL '%s' to set the metrics address didn't work.", r.SusQLPrometheusMetricsUrl))
-			panic(fmt.Sprintf("PANIC [InitializeMetricsExporter]: Parsing the URL '%s' to set the metrics address didn't work (%v)", r.SusQLPrometheusMetricsUrl, parseErr))
+		metricsUrl, parseErr := url.Parse(r.SusQLPrometheusMetricsUrl)
+		if parseErr != nil {
+			return fmt.Errorf("[InitializeMetricsExporter] failed to parse metrics URL '%s': %w", r.SusQLPrometheusMetricsUrl, parseErr)
 		}
+
+		r.Logger.V(2).Info(fmt.Sprintf("[InitializeMetricsExporter] Serving metrics at '%s:%s'...\n", metricsUrl.Hostname(), metricsUrl.Port()))
+
+		go func() {
+			err := http.ListenAndServe(metricsUrl.Hostname()+":"+metricsUrl.Port(), nil)
+			if err != nil {
+				r.Logger.V(0).Error(err, "[InitializeMetricsExporter] ListenAndServe failed")
+				// Note: This runs in a goroutine, so we can't return the error
+				// The error is logged and the operator continues without metrics export
+			}
+		}()
 	}
+	return nil
 }
 
 func (r *LabelGroupReconciler) SetAggregatedEnergyForLabels(totalEnergy float64, prometheusLabels map[string]string) error {
@@ -218,7 +250,7 @@ func (r *LabelGroupReconciler) SetAggregatedCarbonForLabels(totalCarbon float64,
 	// Save aggregated carbon to Prometheus table
 	susqlMetrics.totalCarbon.With(prometheusLabels).Set(totalCarbon)
 
-	r.Logger.V(5).Info(fmt.Sprintf("[SetAggregatedEnergyForLabels] Setting carbon %f for %v.", totalCarbon, prometheusLabels)) // trace
+	r.Logger.V(5).Info(fmt.Sprintf("[SetAggregatedCarbonForLabels] Setting carbon %f for %v.", totalCarbon, prometheusLabels)) // trace
 
 	return nil
 }

--- a/internal/controller/resource_manager.go
+++ b/internal/controller/resource_manager.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2023, 2024.
+Copyright 2023, 2024, 2025, 2026.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
- Bump Go version to 1.24.7
- Update GitHub Actions to v6 (checkout and setup-go) for Node.js 24 support
- Fix lint and build errors (add missing fmt import)
- Update copyright year to 2026
- General code cleanup and maintenance